### PR TITLE
Builder support for audio and video upload

### DIFF
--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_audio.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_audio.py
@@ -1,5 +1,6 @@
 from yowsup.structs import ProtocolEntity, ProtocolTreeNode
 from .message_media_downloadable import DownloadableMediaMessageProtocolEntity
+from .builder_message_media_downloadable import DownloadableMediaMessageBuilder
 class AudioDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtocolEntity):
     '''
     <message t="{{TIME_STAMP}}" from="{{CONTACT_JID}}"
@@ -89,11 +90,16 @@ class AudioDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtoc
         )
         return entity
 
-
+    @staticmethod
+    def getBuilder(jid, filepath):
+        return DownloadableMediaMessageBuilder(AudioDownloadableMediaMessageProtocolEntity, jid, filepath)
 
     @staticmethod
     def fromFilePath(fpath, url, ip, to, mimeType = None, preview = None, filehash = None, filesize = None):
-        entity = DownloadableMediaMessageProtocolEntity.fromFilePath(fpath, url, DownloadableMediaMessageProtocolEntity.MEDIA_TYPE_AUDIO, ip, to, mimeType, preview)
-        entity.__class__ = AudioDownloadableMediaMessageProtocolEntity
-        entity.setAudioProps()
-        return entity
+        builder = AudioDownloadableMediaMessageProtocolEntity.getBuilder(to, fpath)
+        builder.set("url", url)
+        builder.set("ip", ip)
+        #builder.set("caption", caption)
+        builder.set("mimetype", mimeType)
+        #builder.set("dimensions", dimensions)
+        return AudioDownloadableMediaMessageProtocolEntity.fromBuilder(builder)

--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_video.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_video.py
@@ -1,6 +1,7 @@
 from yowsup.structs import ProtocolEntity, ProtocolTreeNode
 from .message_media_downloadable import DownloadableMediaMessageProtocolEntity
 from yowsup.common.tools import VideoTools
+from .builder_message_media_downloadable import DownloadableMediaMessageBuilder
 
 class VideoDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtocolEntity):
     '''
@@ -129,14 +130,26 @@ class VideoDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtoc
         return entity
 
     @staticmethod
+    def getBuilder(jid, filepath):
+        return DownloadableMediaMessageBuilder(VideoDownloadableMediaMessageProtocolEntity, jid, filepath)
+ 
+    @staticmethod
     def fromFilePath(path, url, ip, to, mimeType = None, caption = None):
-        preview = VideoTools.generatePreviewFromVideo(path)
-        entity = DownloadableMediaMessageProtocolEntity.fromFilePath(path, url, DownloadableMediaMessageProtocolEntity.MEDIA_TYPE_VIDEO, ip, to, mimeType, preview)
-        entity.__class__ = VideoDownloadableMediaMessageProtocolEntity
+        #preview = VideoTools.generatePreviewFromVideo(path)
+        #entity = DownloadableMediaMessageProtocolEntity.fromFilePath(path, url, DownloadableMediaMessageProtocolEntity.MEDIA_TYPE_VIDEO, ip, to, mimeType, preview)
+        #entity.__class__ = VideoDownloadableMediaMessageProtocolEntity
 
-        width, height, bitrate, duration = VideoTools.getVideoProperties(path)
-        assert width, "Could not determine video properties"
+        #width, height, bitrate, duration = VideoTools.getVideoProperties(path)
+        #assert width, "Could not determine video properties"
 
-        duration = int(duration)
-        entity.setVideoProps('raw', width, height, duration=duration, seconds=duration, caption=caption)
-        return entity
+        #duration = int(duration)
+        #entity.setVideoProps('raw', width, height, duration=duration, seconds=duration, caption=caption)
+        #return entity
+        builder = VideoDownloadableMediaMessageProtocolEntity.getBuilder(to, path)
+        builder.set("url", url)
+        builder.set("ip", ip)
+        #builder.set("caption", caption)
+        builder.set("mimetype", mimeType)
+        #builder.set("dimensions", dimensions)
+        return VideoDownloadableMediaMessageProtocolEntity.fromBuilder(builder)
+


### PR DESCRIPTION
Trying to upload an audio or video from cli interface, I got
entity = DownloadableMediaMessageProtocolEntity.fromFilePath(fpath, url, DownloadableMediaMessageProtocolEntity.MEDIA_TYPE_AUDIO, ip, to, mimeType, preview)
AttributeError: type object 'DownloadableMediaMessageProtocolEntity' has no attribute 'fromFilePath'

I rewrite both to use builder, similar with the image class